### PR TITLE
#27: no empty item descriptions

### DIFF
--- a/src/advenjure/items.cljc
+++ b/src/advenjure/items.cljc
@@ -31,8 +31,10 @@
 
 (defn make
   ([names description & {:as extras}]
-   (when (empty? description)
-    (throw (Exception. "Item description may not be empty")))
+   (when (-> description
+           (clojure.string/replace #"\s" "")
+           empty?)
+     (throw (Exception. "Item description may not be empty")))
    (let [names (if (string? names) [names] names)]
      (map->Item (merge {:names names :description description}
                        (open-defaults extras)

--- a/src/advenjure/items.cljc
+++ b/src/advenjure/items.cljc
@@ -31,6 +31,8 @@
 
 (defn make
   ([names description & {:as extras}]
+   (when (empty? description)
+    (throw (Exception. "Item description may not be empty")))
    (let [names (if (string? names) [names] names)]
      (map->Item (merge {:names names :description description}
                        (open-defaults extras)

--- a/test/advenjure/dialogs_test.clj
+++ b/test/advenjure/dialogs_test.clj
@@ -58,14 +58,14 @@
   (with-redefs [print-line print-mock
                 read-key   (fn [] (go nil))]
     (testing "linear dialog"
-      (let [character (it/make ["character"] "" :dialog `simple)
+      (let [character (it/make ["character"] "you" :dialog `simple)
             new-state (assoc-in game-state
                                 [:room-map :bedroom :items] #{character})]
         (talk new-state "character")
         (is-output @output ["ME —Hi!" "YOU —Hey there!"])))
 
     (testing "compound literal dialog"
-      (let [character (it/make ["character"] "" :dialog `compound)
+      (let [character (it/make ["character"] "you" :dialog `compound)
             new-state (assoc-in game-state
                                 [:room-map :bedroom :items] #{character})]
         (talk new-state "character")
@@ -73,21 +73,21 @@
 
 
     (testing "compound referenced dialog"
-      (let [character (it/make ["character"] "" :dialog `referenced)
+      (let [character (it/make ["character"] "you" :dialog `referenced)
             new-state (assoc-in game-state
                                 [:room-map :bedroom :items] #{character})]
         (talk new-state "character")
         (is-output @output ["ME —Hi!" "YOU —Hey there!" "ME —Bye then"])))
 
     (testing "conditional event"
-      (let [character (it/make ["character"] "" :dialog `cond-event)
+      (let [character (it/make ["character"] "you" :dialog `cond-event)
             new-state (assoc-in game-state
                                 [:room-map :bedroom :items] #{character})]
         (talk new-state "character")
         (is-output @output "ME —I'm full.")))
 
     (testing "conditional item"
-      (let [character (it/make ["character"] "" :dialog `cond-item)
+      (let [character (it/make ["character"] "you" :dialog `cond-item)
             new-state (assoc-in game-state
                                 [:room-map :bedroom :items] #{character})]
         (talk new-state "character")
@@ -97,7 +97,7 @@
   (with-redefs [print-line print-mock
                 read-key   (fn [] (go "1"))]
     (testing "simple choice and go back"
-      (let [character (it/make ["character"] "" :dialog `choice)
+      (let [character (it/make ["character"] "you" :dialog `choice)
             new-state (assoc-in game-state
                                 [:room-map :bedroom :items] #{character})]
         (talk new-state "character")

--- a/test/advenjure/items_test.clj
+++ b/test/advenjure/items_test.clj
@@ -10,6 +10,11 @@
 (def sword (make ["sword" "silver sword"]))
 (def wsword (make ["sword" "wooden sword"]))
 
+(deftest description-test
+  (testing "empty description fails"
+    (is (thrown-with-msg? Exception #"Item description may not be empty"
+          (make ["foo"] "")))))
+
 (deftest describe-container-test
   (testing "describe lists items"
     (is (= (describe-container sack)

--- a/test/advenjure/items_test.clj
+++ b/test/advenjure/items_test.clj
@@ -11,9 +11,14 @@
 (def wsword (make ["sword" "wooden sword"]))
 
 (deftest description-test
+  (testing "nonempty description succeeds"
+    (is (make ["foo"] "a foo!")))
   (testing "empty description fails"
     (is (thrown-with-msg? Exception #"Item description may not be empty"
-          (make ["foo"] "")))))
+          (make ["foo"] ""))))
+  (testing "all-spaces description fails"
+    (is (thrown-with-msg? Exception #"Item description may not be empty"
+          (make ["foo"] "  ")))))
 
 (deftest describe-container-test
   (testing "describe lists items"


### PR DESCRIPTION
Hi! This app is a great idea. I picked what looked like a really simple issue to try contributing.

* throw a generic exception if item description is empty
* add test
* update tests that were using empty item descriptions

Is simply throwing some message what you had in mind? Am I missing any more complicated way of validating inputs?