### PR TITLE
Added verb synonyms

### DIFF
--- a/src/advenjure/items.cljc
+++ b/src/advenjure/items.cljc
@@ -31,12 +31,9 @@
 
 (defn apply-synonyms
   [item]
-  (let [keys (keys item)]
-    (map (fn [field]
-           (let [[key value] field]
-             (if (> (.indexOf keys value) -1)
-               {key (value item)}
-               field))) item)))
+  (reduce-kv
+    (fn [map key value]
+      (assoc map key (get item value value))) {} item))
 
 (defn make
   ([names description & {:as extras}]

--- a/src/advenjure/items.cljc
+++ b/src/advenjure/items.cljc
@@ -29,16 +29,25 @@
 
 (defn talk-defaults [item] (if (:dialog item) {:talk true}))
 
+(defn apply-synonyms
+  [item]
+  (let [keys (keys item)]
+    (map (fn [field]
+           (let [[key value] field]
+             (if (> (.indexOf keys value) -1)
+               {key (value item)}
+               field))) item)))
+
 (defn make
   ([names description & {:as extras}]
    (let [names (if (string? names) [names] names)]
-     (map->Item (merge {:names names :description description}
+     (map->Item (apply-synonyms (merge {:names names :description description}
                        (open-defaults extras)
                        (unlock-defaults extras)
                        (talk-defaults extras)
                        (climb-defaults extras)
                        (use-with-defaults extras)
-                       extras))))
+                       extras)))))
   ([names]
    (make names (_ "There was nothing special about it."))))
 

--- a/test/advenjure/items_test.clj
+++ b/test/advenjure/items_test.clj
@@ -9,6 +9,7 @@
 (def closed-sack (assoc sack :closed true))
 (def sword (make ["sword" "silver sword"]))
 (def wsword (make ["sword" "wooden sword"]))
+(def book (make "Book" "It's a book" :unlock "It's bound" :open :unlock))
 
 (deftest describe-container-test
   (testing "describe lists items"
@@ -50,3 +51,6 @@
       (is (= (get-from item-set "wooden sword") [wsword]))
       (is (= (into #{} (get-from item-set "sword")) #{wsword sword})))))
 
+(deftest verb-synonym-test
+  (testing "verb synonyms"
+    (is (= (:open book) (:unlock book)))))


### PR DESCRIPTION
Closes issue #18 

I've done what you've suggested, so if you specify another verb it will use that instead.

I'm new to Clojure so I'm not sure on the implementation

apply-synonyms finds values in the item map, and copies the values from
synonyms over. E.g.
:unlock "Won't open" :open :unlock
Changes to
:unlock "Won't open" :open "Won't open"